### PR TITLE
Connector fixes

### DIFF
--- a/src/main/java/com/luxof/lapisworks/interop/oneironaut/FuckingInexhaustiblePhials.java
+++ b/src/main/java/com/luxof/lapisworks/interop/oneironaut/FuckingInexhaustiblePhials.java
@@ -3,13 +3,11 @@ package com.luxof.lapisworks.interop.oneironaut;
 import at.petrak.hexcasting.api.addldata.ADHexHolder;
 import at.petrak.hexcasting.api.casting.eval.env.PackagedItemCastEnv;
 import at.petrak.hexcasting.api.casting.eval.env.PlayerBasedCastEnv;
+import at.petrak.hexcasting.api.item.MediaHolderItem;
 import at.petrak.hexcasting.xplat.IXplatAbstractions;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import net.beholderface.oneironaut.item.BottomlessMediaItem;
-import net.beholderface.oneironaut.registry.OneironautItemRegistry;
 
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.Item;
@@ -31,7 +29,7 @@ public class FuckingInexhaustiblePhials {
             ItemStack trinket = player.getStackInHand(ctx.getCastingHand());
             ADHexHolder hexHolder = IXplatAbstractions.INSTANCE.findHexHolder(trinket);
             if (!hexHolder.canDrawMediaFromInventory())
-                return trinket.isOf(OneironautItemRegistry.BOTTOMLESS_CASTING_ITEM.get())
+                return trinket.isOf(BOTTOMLESS_MEDIA_ITEM)
                     ? IXplatAbstractions.INSTANCE.findMediaHolder(trinket).getMedia() : 0L;
         }
         PlayerInventory inv = player.getInventory();
@@ -41,7 +39,7 @@ public class FuckingInexhaustiblePhials {
         items.addAll(inv.armor);
         long total = 0L;
         for (ItemStack item : items) {
-            total += item.isOf(BOTTOMLESS_MEDIA_ITEM) ? ((BottomlessMediaItem)item.getItem()).getMedia(item) : 0;
+            total += item.isOf(BOTTOMLESS_MEDIA_ITEM) ? ((MediaHolderItem)item.getItem()).getMedia(item) : 0;
         }
         return total;
     }

--- a/src/main/java/com/luxof/lapisworks/interop/oneironaut/FuckingInexhaustiblePhials.java
+++ b/src/main/java/com/luxof/lapisworks/interop/oneironaut/FuckingInexhaustiblePhials.java
@@ -12,10 +12,16 @@ import net.beholderface.oneironaut.item.BottomlessMediaItem;
 import net.beholderface.oneironaut.registry.OneironautItemRegistry;
 
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
 
 public class FuckingInexhaustiblePhials {
+    //Get the item from registry to prevent crashing with Oneironaut Forge
+    static final Item BOTTOMLESS_MEDIA_ITEM = Registries.ITEM.get(new Identifier("oneironaut", "endless_phial"));
+
     public static long getBottomlessContrib(PlayerBasedCastEnv ctx) {
         ServerPlayerEntity player = ((ServerPlayerEntity)ctx.getCastingEntity());
 
@@ -28,7 +34,6 @@ public class FuckingInexhaustiblePhials {
                 return trinket.isOf(OneironautItemRegistry.BOTTOMLESS_CASTING_ITEM.get())
                     ? IXplatAbstractions.INSTANCE.findMediaHolder(trinket).getMedia() : 0L;
         }
-
         PlayerInventory inv = player.getInventory();
         List<ItemStack> items = new ArrayList<>();
         items.addAll(inv.main);
@@ -36,9 +41,7 @@ public class FuckingInexhaustiblePhials {
         items.addAll(inv.armor);
         long total = 0L;
         for (ItemStack item : items) {
-            total += item.isOf(
-                OneironautItemRegistry.BOTTOMLESS_MEDIA_ITEM.get()
-            ) ? ((BottomlessMediaItem)item.getItem()).getMedia(item) : 0;
+            total += item.isOf(BOTTOMLESS_MEDIA_ITEM) ? ((BottomlessMediaItem)item.getItem()).getMedia(item) : 0;
         }
         return total;
     }

--- a/src/main/java/com/luxof/lapisworks/mixin/GuiSpellcastingMixin.java
+++ b/src/main/java/com/luxof/lapisworks/mixin/GuiSpellcastingMixin.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(value = GuiSpellcasting.class, remap = false)
+@Mixin(value = GuiSpellcasting.class)
 public class GuiSpellcastingMixin {
     @Inject(
         method = "tick",


### PR DESCRIPTION
Deposit media crashes because of new Inexhaustible Phial check,
because classes are not the same between [Oneironaut](https://github.com/beholderface/oneironaut) and it's fork [Oneironaut Forge](https://github.com/JaaiDead/oneironautfinal).
The workaround is snatching the item class from the registry instead.

Also, with Sinytra Connector, Fabric mods kinda load after forge mod cycle, so the minecraft and forge mod classes are already mangled, including HexCasting. I'm not sure where is `remap = false` can be needed really, it seems to be disadvantageous.

Also, chalk *with patterns* still crashes though on forge unfortunately.