### PR TITLE
Invert player check in BanishMySent

### DIFF
--- a/src/main/java/com/luxof/lapisworks/actions/wizard/enchsent/BanishMySent.java
+++ b/src/main/java/com/luxof/lapisworks/actions/wizard/enchsent/BanishMySent.java
@@ -24,7 +24,7 @@ public class BanishMySent extends SpellActionNCT {
     public int argc = 0;
 
     public Result execute(HexIotaStack stack, CastingEnvironment ctx) {
-        if (ctx.getCastingEntity() instanceof ServerPlayerEntity)
+        if (!(ctx.getCastingEntity() instanceof ServerPlayerEntity))
             throw new MishapBadCaster();
         
         return new Result(


### PR DESCRIPTION
Currently, BanishMySent mishaps if the caster _is_ a player, rather than if they aren't. This PR fixes that.